### PR TITLE
Default log level.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/express-logger",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3374,9 +3374,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/express-logger",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Default express logging middleware to match BYU app dev logging standards",
   "main": "dist/express-logger.js",
   "types": "dist/express-logger.d.ts",

--- a/src/express-logger.ts
+++ b/src/express-logger.ts
@@ -9,7 +9,8 @@ export function LoggerMiddleware (options?: PinoHttp.Options): HttpLogger {
       return req.headers['x-amzn-trace-id'] ?? randomUuid() // use the amazon trace id as the request id
     },
     customLogLevel: (res, err) => {
-      if (res.statusCode >= 400) return 'error'
+      if (res.statusCode >= 400 && res.statusCode < 500) return 'warn'
+      else if (res.statusCode >= 500) return 'error'
       else return 'info'
     },
     ...options

--- a/src/express-logger.ts
+++ b/src/express-logger.ts
@@ -9,8 +9,8 @@ export function LoggerMiddleware (options?: PinoHttp.Options): HttpLogger {
       return req.headers['x-amzn-trace-id'] ?? randomUuid() // use the amazon trace id as the request id
     },
     customLogLevel: (res, err) => {
-      if (res.statusCode >= 400) return "error"
-      else return "info"
+      if (res.statusCode >= 400) return 'error'
+      else return 'info'
     },
     ...options
   })

--- a/src/express-logger.ts
+++ b/src/express-logger.ts
@@ -8,6 +8,10 @@ export function LoggerMiddleware (options?: PinoHttp.Options): HttpLogger {
     genReqId: req => {
       return req.headers['x-amzn-trace-id'] ?? randomUuid() // use the amazon trace id as the request id
     },
+    customLogLevel: (res, err) => {
+      if (res.statusCode >= 400) return "error"
+      else return "info"
+    },
     ...options
   })
 }


### PR DESCRIPTION
Ref: My Slack thread in #developer-experience

This sets the default log level for responses with codes >= 400 as `error`. We can't adjust it based on what the client receives and the server responds with because we only have what the server responds with provided to the function. Developers can override this by passing in their own function as part of the logger options when instantiating the middleware.