### PR TITLE
Fix CommonJS equivalent in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ app.use(LoggerMiddleware())
 <p>
 
 ```javascript
-const { default: LoggerMiddleware } = require('@byu-oit/express-logger')
+const { LoggerMiddleware } = require('@byu-oit/express-logger')
 
 const app = Express()
 


### PR DESCRIPTION
The CommonJS equivalent for this: 
```typescript
export function LoggerMiddleware () {}
```

is this:
```javascript
exports.LoggerMiddleware = function LoggerMiddleware () {}
```

The imports should also be the same. So this:

```typescript
import { LoggerMiddleware } from '@byu-oit/express-logger'
```

should map to this:
```javascript
const { LoggerMiddleware } = require('@byu-oit/express-logger')
```

Here's what the imported object looks like in a CommonJS project:
<img width="550" alt="Screen Shot 2021-09-22 at 4 42 38 PM" src="https://user-images.githubusercontent.com/20521760/134431910-1b602d2f-73a9-477f-a815-de40a7545828.png">