### PR TITLE
Update dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     target-branch: "main"
     # Requesting reviews from yourself makes Dependabot PRs easy to find (https://github.com/pulls/review-requested)
     reviewers:
-      - "yoshutch"
+      - byu-oit/byu-apps-full-stack
+      - byu-oit/developer-experience
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -19,4 +20,5 @@ updates:
     target-branch: "main"
     # Requesting reviews from yourself makes Dependabot PRs easy to find (https://github.com/pulls/review-requested)
     reviewers:
-      - "yoshutch"
+      - byu-oit/byu-apps-full-stack
+      - byu-oit/developer-experience


### PR DESCRIPTION
Update dependabot to use teams instead of users as reviewers for each repo.